### PR TITLE
Fix Undefined Variable cmd_args in cli/src/services/mod.rs and Update Related Tests"

### DIFF
--- a/cli/src/services/mod.rs
+++ b/cli/src/services/mod.rs
@@ -52,7 +52,7 @@ impl fmt::Display for Service {
         #[cfg(debug_assertions)]
         let command = format!("cargo run --bin {} {}", &bin, &self.args.clone().unwrap());
         #[cfg(not(debug_assertions))]
-        let command = format!("{} {}", &bin, &cmd_args);
+        let command = format!("{} {}", &bin, &self.args.clone().unwrap());
 
         write!(f, "{}", command)
     }

--- a/cli/src/test/mod.rs
+++ b/cli/src/test/mod.rs
@@ -3,7 +3,6 @@ mod cli {
     // Error Handling
     use miette::{IntoDiagnostic, Result};
 
-    use crate::services::types::{Action, Service};
 
     use assert_cmd::prelude::*; // Add methods on commands
     use std::process::Command; // Run commnds


### PR DESCRIPTION
# Description

 I run `cargo install --git https://github.com/pipelight/pipelight` and encountered an error. The error details are as follows. and I have made the necessary changes to resolve the issue.

##  Error Details 
```rust
error[E0425]: cannot find value `cmd_args` in this scope
  --> cli/src/services/mod.rs:55:47
   |
55 |         let command = format!("{} {}", &bin, &cmd_args);
   |                                               ^^^^^^^^ not found in this scope
```
error: could not compile `cli` (build script) due to 1 previous error; 15 warnings emitted

## Changes Made

cli/src/services/mod.rs
cli/src/test/mod.rs

## Notes
Please let me know if any further changes or refinements are needed. Thank you!